### PR TITLE
Fix Electron desktop app

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -1,49 +1,51 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
-    <meta charset='utf-8'>
-    <link rel="stylesheet" type="text/css" href="../Orca/desktop/sources/links/main.css"/>
-    <link rel="stylesheet" type="text/css" href="../links/main.css"/>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/lib/acels.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/lib/theme.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/lib/history.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/lib/source.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/library.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/io.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/operator.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/orca.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/transpose.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/io/cc.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/io/midi.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/io/mono.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/io/osc.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/core/io/udp.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/clock.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/commander.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/cursor.js"></script>
-    <script type="text/javascript" src="../Orca/desktop/sources/scripts/client.js"></script>
-    <script type="text/javascript" src="../scripts/lib/tone.js"></script>
-    <script type="text/javascript" src="../scripts/kit.js"></script>
-    <script type="text/javascript" src="../scripts/knob.js"></script>
-    <script type="text/javascript" src="../scripts/mixer.js"></script>
-    <script type="text/javascript" src="../scripts/rack.js"></script>
-    <script type="text/javascript" src="../scripts/orca_play.js"></script>
-    <title>OrcaPlay</title>
+    <meta charset="utf-8" />
+    <title>ORCΛ PLΛY</title>
+    <link rel="stylesheet" href="../links/main.css" />
   </head>
   <body>
-    <script>
-      'use strict'
-
-      const client = new Client()
-      const orcaPlay = new OrcaPlay(client, '../media')
-
-      client.install(document.body)
-      orcaPlay.install(document.body)
-
-      window.addEventListener('load', () => { 
-        client.start()
-        client.acels.inject('Orca')
-        orcaPlay.start()
-      })
-    </script>
+    <div id="info-container" class="hidden">
+      <div id="info">
+        <div id="info-header">
+          <span id="info-close" class="icon" >
+            <svg title="hide info window" width="32px" height="32px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <path d="M16 8L8 16M8.00001 8L16 16" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path> </g></svg>
+          </span>
+        </div>
+        <div id="info-body">
+          <div id="info-content">
+            <h1>ORCΛ PLΛY</h1>
+            <p>Welcome to ORCΛ PLΛY a combination of the famos Orca esoteric programming language and the Pilot synthesizer.
+              This combination allows to run standalone Orca in a webbrowser without additional setup.</p>
+            <h2>Getting started</h2>
+            <p>Press CmdOrCtrl+R to load a random example</p>
+            <template id="info-table-template-row">
+              <tr><td></td><td></td></tr>
+            </template>
+            <template id="info-table-template-row-group">
+              <tr><td colspan=2></td></tr>
+            </template>
+            <template id="info-table-template">
+              <div>
+                <hr>
+                <h2></h2>
+                <table class="info-table">
+                  <thead><tr><th></th><th></th></tr></thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="orca" class="orca_shared_screen">
+      <iframe id="orca-iframe" src="../Orca/index.html"></iframe>
+    </div>
+    <div id="pilot" class="pilot_visible">
+      <iframe id="pilot-iframe" src="../Pilot/browser/index.html"></iframe>
+    </div>
+    <script type="module" src="../scripts/orca_play.js"></script>
   </body>
 </html>

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -2,14 +2,29 @@
 
 /* global createWindow */
 
-const { app, BrowserWindow, Menu } = require('electron')
+const { app, BrowserWindow, Menu, protocol } = require('electron')
 const path = require('path')
 
 let isShown = true
 
 app.win = null
 
+// Register app:// as a standard secure scheme so all frames share the same
+// origin — this is what allows orca_play.js to access iframe contentWindows.
+protocol.registerSchemesAsPrivileged([{
+  scheme: 'app',
+  privileges: { standard: true, secure: true, supportFetchAPI: true }
+}])
+
+app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required')
+
 app.on('ready', () => {
+  // Serve the project root via app://app/
+  protocol.registerFileProtocol('app', (request, callback) => {
+    const filePath = request.url.replace(/^app:\/\/app/, '')
+    callback({ path: path.normalize(path.join(__dirname, '..', filePath)) })
+  })
+
   app.win = new BrowserWindow({
     width: 780,
     height: 462,
@@ -24,7 +39,7 @@ app.on('ready', () => {
     webPreferences: { zoomFactor: 1.0, nodeIntegration: true, backgroundThrottling: false }
   })
 
-  app.win.loadURL(`file://${__dirname}/index.html`)
+  app.win.loadURL('app://app/desktop/index.html')
   // app.inspect()
 
   app.win.on('closed', () => {

--- a/scripts/share.js
+++ b/scripts/share.js
@@ -1,57 +1,75 @@
 import { nanoid } from 'https://unpkg.com/nanoid@4.0.2/nanoid.js'
-import 'https://unpkg.com/@supabase/supabase-js@2'
+
+const isDesktop = window.location.protocol === 'file:'
+
+let supabaseDB = null
+let supabaseLoaded = false
+
+async function getSupabase () {
+    if (isDesktop) return null
+    if (supabaseLoaded) return supabaseDB
+    supabaseLoaded = true
+    try {
+        await import('https://unpkg.com/@supabase/supabase-js@2')
+        const { createClient } = supabase
+        supabaseDB = createClient(
+            'https://qfxcjflnheydozqmuodf.supabase.co',
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFmeGNqZmxuaGV5ZG96cW11b2RmIiwicm9sZSI6ImFub24iLCJpYXQiOjE2Nzk4NTM1MTMsImV4cCI6MTk5NTQyOTUxM30.aSwuGJJXod9BZVXYSTLvxrzU5puuHXGpFI_07XXsvy8',
+        )
+    } catch (err) {
+        console.warn('Supabase not available, share feature disabled.', err)
+    }
+    return supabaseDB
+}
 
 export default function Share () {
-    // Create a single supabase client for interacting with your database
-    const { createClient } = supabase
-    const supabaseDB = createClient(
-        'https://qfxcjflnheydozqmuodf.supabase.co',
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFmeGNqZmxuaGV5ZG96cW11b2RmIiwicm9sZSI6ImFub24iLCJpYXQiOjE2Nzk4NTM1MTMsImV4cCI6MTk5NTQyOTUxM30.aSwuGJJXod9BZVXYSTLvxrzU5puuHXGpFI_07XXsvy8',
-    );
     this.initCode = async () => {
         try {
-            const initialUrl = window.location.href;
-            const hash = initialUrl.split('?')[1]?.split('#')?.[0];
-            const codeParam = window.location.href.split('#')[1];
+            const codeParam = window.location.href.split('#')[1]
             if (codeParam) {
-                // looking like https://karstenj.github.io/orca-play/#ImMzIGUzIg%3D%3D (hash length depends on code length)
-                return atob(decodeURIComponent(codeParam || ''));
-            } else if (hash) {
-                return supabaseDB
+                return atob(decodeURIComponent(codeParam || ''))
+            }
+            const db = await getSupabase()
+            if (!db) { return }
+            const hash = window.location.href.split('?')[1]?.split('#')?.[0]
+            if (hash) {
+                return db
                     .from('code')
                     .select('code')
                     .eq('hash', hash)
                     .then(({ data, error }) => {
-                    if (error) {
-                        console.warn('failed to load hash', err);
-                    }
-                    if (data.length) {
-                        console.log('load hash from database', hash);
-                        return data[0].code;
-                    }
-                });
+                        if (error) { console.warn('failed to load hash', error) }
+                        if (data.length) {
+                            console.log('load hash from database', hash)
+                            return data[0].code
+                        }
+                    })
             }
         } catch (err) {
-          console.warn('failed to load code', err);
-        }         
-    }
-    this.handleShare = async (codeToShare) => {
-        // generate uuid in the browser
-        const hash = nanoid(12);
-        const shareUrl = window.location.origin + window.location.pathname + '?' + hash;
-        const { data, error } = await supabaseDB.from('code').insert([{ code: codeToShare, hash }]);
-        if (!error) {
-          // copy shareUrl to clipboard
-          await navigator.clipboard.writeText(shareUrl);
-          const message = `Link copied to clipboard: ${shareUrl}`;
-          alert(message);
-          // alert(message);
-          console.log(message);
-        } else {
-          console.log('error', error);
-          const message = `Error: ${error.message}`;
-          // alert(message);
-          console.log(message);
+            console.warn('failed to load code', err)
         }
-    };
+    }
+
+    this.handleShare = async (codeToShare) => {
+        const db = await getSupabase()
+        if (!db) {
+            const encoded = encodeURIComponent(btoa(codeToShare))
+            const shareUrl = `https://karstenj.github.io/orca-play/#${encoded}`
+            await navigator.clipboard.writeText(shareUrl)
+            alert(`Link copied to clipboard: ${shareUrl}`)
+            return
+        }
+        const hash = nanoid(12)
+        const shareUrl = window.location.origin + window.location.pathname + '?' + hash
+        const { data, error } = await db.from('code').insert([{ code: codeToShare, hash }])
+        if (!error) {
+            await navigator.clipboard.writeText(shareUrl)
+            const message = `Link copied to clipboard: ${shareUrl}`
+            alert(message)
+            console.log(message)
+        } else {
+            console.log('error', error)
+            console.log(`Error: ${error.message}`)
+        }
+    }
 }


### PR DESCRIPTION
- Rewrite desktop/index.html to use iframes (matching web version) and load orca_play.js as ES module
- Register app:// protocol in main.js so all frames share the same origin, enabling iframe contentWindow access
- Disable AudioContext autoplay restriction via --autoplay-policy flag
- Fix share.js to load Supabase lazily (no top-level await, compatible with Electron 8)
- Provide hash-based share URL fallback when Supabase is unavailable (desktop)
- Update Orca submodule